### PR TITLE
msm8998-common:add "unprocessed-stereo-mic" to audio config

### DIFF
--- a/audio/mixer_paths_i2s.xml
+++ b/audio/mixer_paths_i2s.xml
@@ -235,4 +235,8 @@
         <path name="handset-mic" />
     </path>
 
+    <path name="unprocessed-stereo-mic">
+	<path name="voice-rec-dmic-ef" />
+     </path>
+
 </mixer>


### PR DESCRIPTION
-taken from https://android.googlesource.com/device/google/marlin/+/refs/heads/android10-release/mixer_paths.xml
-Fixes no audio while video recording on Q